### PR TITLE
Re-added Laser tower audio

### DIFF
--- a/Assets/Scenes/Level1.unity
+++ b/Assets/Scenes/Level1.unity
@@ -29639,6 +29639,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7336903875735698374, guid: b1e26fbb641dbc14db5a85bd1c511e00,
         type: 3}
+      propertyPath: gameSFXSounds.Array.size
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336903875735698374, guid: b1e26fbb641dbc14db5a85bd1c511e00,
+        type: 3}
       propertyPath: musicSlider
       value: 
       objectReference: {fileID: 1846353219}
@@ -29647,6 +29652,41 @@ PrefabInstance:
       propertyPath: sfxSlider
       value: 
       objectReference: {fileID: 783212940}
+    - target: {fileID: 7336903875735698374, guid: b1e26fbb641dbc14db5a85bd1c511e00,
+        type: 3}
+      propertyPath: gameSFXSounds.Array.data[5].name
+      value: LaserTowerShot
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336903875735698374, guid: b1e26fbb641dbc14db5a85bd1c511e00,
+        type: 3}
+      propertyPath: gameSFXSounds.Array.data[5].audioClip
+      value: 
+      objectReference: {fileID: 8300000, guid: f7f2b958b23574551b561f7e871a8306, type: 3}
+    - target: {fileID: 7336903875735698374, guid: b1e26fbb641dbc14db5a85bd1c511e00,
+        type: 3}
+      propertyPath: gameSFXSounds.Array.data[5].volume
+      value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336903875735698374, guid: b1e26fbb641dbc14db5a85bd1c511e00,
+        type: 3}
+      propertyPath: gameSFXSounds.Array.data[5].pitch
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336903875735698374, guid: b1e26fbb641dbc14db5a85bd1c511e00,
+        type: 3}
+      propertyPath: gameSFXSounds.Array.data[3].volume
+      value: 0.17
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336903875735698374, guid: b1e26fbb641dbc14db5a85bd1c511e00,
+        type: 3}
+      propertyPath: gameSFXSounds.Array.data[3].audioClip
+      value: 
+      objectReference: {fileID: 8300000, guid: 1d410a07dc504a147822ac4a890c3519, type: 3}
+    - target: {fileID: 7336903875735698374, guid: b1e26fbb641dbc14db5a85bd1c511e00,
+        type: 3}
+      propertyPath: gameSFXSounds.Array.data[3].name
+      value: FlameTowerShot
+      objectReference: {fileID: 0}
     - target: {fileID: 7336903875735698375, guid: b1e26fbb641dbc14db5a85bd1c511e00,
         type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Scenes/Level2.unity
+++ b/Assets/Scenes/Level2.unity
@@ -17302,6 +17302,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7336903875735698374, guid: b1e26fbb641dbc14db5a85bd1c511e00,
         type: 3}
+      propertyPath: gameSFXSounds.Array.size
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336903875735698374, guid: b1e26fbb641dbc14db5a85bd1c511e00,
+        type: 3}
       propertyPath: musicSlider
       value: 
       objectReference: {fileID: 6508861434526626280}
@@ -17310,6 +17315,36 @@ PrefabInstance:
       propertyPath: sfxSlider
       value: 
       objectReference: {fileID: 6508861433459051815}
+    - target: {fileID: 7336903875735698374, guid: b1e26fbb641dbc14db5a85bd1c511e00,
+        type: 3}
+      propertyPath: gameSFXSounds.Array.data[3].name
+      value: FlameTowerShot
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336903875735698374, guid: b1e26fbb641dbc14db5a85bd1c511e00,
+        type: 3}
+      propertyPath: gameSFXSounds.Array.data[5].name
+      value: LaserTowerShot
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336903875735698374, guid: b1e26fbb641dbc14db5a85bd1c511e00,
+        type: 3}
+      propertyPath: gameSFXSounds.Array.data[5].audioClip
+      value: 
+      objectReference: {fileID: 8300000, guid: f7f2b958b23574551b561f7e871a8306, type: 3}
+    - target: {fileID: 7336903875735698374, guid: b1e26fbb641dbc14db5a85bd1c511e00,
+        type: 3}
+      propertyPath: gameSFXSounds.Array.data[5].volume
+      value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336903875735698374, guid: b1e26fbb641dbc14db5a85bd1c511e00,
+        type: 3}
+      propertyPath: gameSFXSounds.Array.data[5].pitch
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336903875735698374, guid: b1e26fbb641dbc14db5a85bd1c511e00,
+        type: 3}
+      propertyPath: gameSFXSounds.Array.data[3].audioClip
+      value: 
+      objectReference: {fileID: 8300000, guid: 1d410a07dc504a147822ac4a890c3519, type: 3}
     - target: {fileID: 7336903875735698375, guid: b1e26fbb641dbc14db5a85bd1c511e00,
         type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Scenes/Level3.unity
+++ b/Assets/Scenes/Level3.unity
@@ -9387,6 +9387,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7336903875735698374, guid: b1e26fbb641dbc14db5a85bd1c511e00,
         type: 3}
+      propertyPath: gameSFXSounds.Array.size
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336903875735698374, guid: b1e26fbb641dbc14db5a85bd1c511e00,
+        type: 3}
       propertyPath: musicSlider
       value: 
       objectReference: {fileID: 1799150441}
@@ -9395,6 +9400,36 @@ PrefabInstance:
       propertyPath: sfxSlider
       value: 
       objectReference: {fileID: 1856867965}
+    - target: {fileID: 7336903875735698374, guid: b1e26fbb641dbc14db5a85bd1c511e00,
+        type: 3}
+      propertyPath: gameSFXSounds.Array.data[5].name
+      value: LaserTowerShot
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336903875735698374, guid: b1e26fbb641dbc14db5a85bd1c511e00,
+        type: 3}
+      propertyPath: gameSFXSounds.Array.data[5].audioClip
+      value: 
+      objectReference: {fileID: 8300000, guid: f7f2b958b23574551b561f7e871a8306, type: 3}
+    - target: {fileID: 7336903875735698374, guid: b1e26fbb641dbc14db5a85bd1c511e00,
+        type: 3}
+      propertyPath: gameSFXSounds.Array.data[5].volume
+      value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336903875735698374, guid: b1e26fbb641dbc14db5a85bd1c511e00,
+        type: 3}
+      propertyPath: gameSFXSounds.Array.data[5].pitch
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336903875735698374, guid: b1e26fbb641dbc14db5a85bd1c511e00,
+        type: 3}
+      propertyPath: gameSFXSounds.Array.data[3].name
+      value: FlameTowerShot
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336903875735698374, guid: b1e26fbb641dbc14db5a85bd1c511e00,
+        type: 3}
+      propertyPath: gameSFXSounds.Array.data[3].audioClip
+      value: 
+      objectReference: {fileID: 8300000, guid: 1d410a07dc504a147822ac4a890c3519, type: 3}
     - target: {fileID: 7336903875735698375, guid: b1e26fbb641dbc14db5a85bd1c511e00,
         type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Scenes/Level4.unity
+++ b/Assets/Scenes/Level4.unity
@@ -1225,6 +1225,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7336903875735698374, guid: b1e26fbb641dbc14db5a85bd1c511e00,
         type: 3}
+      propertyPath: gameSFXSounds.Array.size
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336903875735698374, guid: b1e26fbb641dbc14db5a85bd1c511e00,
+        type: 3}
       propertyPath: musicSlider
       value: 
       objectReference: {fileID: 6508861434147864599}
@@ -1233,6 +1238,36 @@ PrefabInstance:
       propertyPath: sfxSlider
       value: 
       objectReference: {fileID: 6508861435215117528}
+    - target: {fileID: 7336903875735698374, guid: b1e26fbb641dbc14db5a85bd1c511e00,
+        type: 3}
+      propertyPath: gameSFXSounds.Array.data[3].audioClip
+      value: 
+      objectReference: {fileID: 8300000, guid: 1d410a07dc504a147822ac4a890c3519, type: 3}
+    - target: {fileID: 7336903875735698374, guid: b1e26fbb641dbc14db5a85bd1c511e00,
+        type: 3}
+      propertyPath: gameSFXSounds.Array.data[3].name
+      value: FlameTowerShot
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336903875735698374, guid: b1e26fbb641dbc14db5a85bd1c511e00,
+        type: 3}
+      propertyPath: gameSFXSounds.Array.data[5].name
+      value: LaserTowerShot
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336903875735698374, guid: b1e26fbb641dbc14db5a85bd1c511e00,
+        type: 3}
+      propertyPath: gameSFXSounds.Array.data[5].audioClip
+      value: 
+      objectReference: {fileID: 8300000, guid: f7f2b958b23574551b561f7e871a8306, type: 3}
+    - target: {fileID: 7336903875735698374, guid: b1e26fbb641dbc14db5a85bd1c511e00,
+        type: 3}
+      propertyPath: gameSFXSounds.Array.data[5].volume
+      value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336903875735698374, guid: b1e26fbb641dbc14db5a85bd1c511e00,
+        type: 3}
+      propertyPath: gameSFXSounds.Array.data[5].pitch
+      value: 1.5
+      objectReference: {fileID: 0}
     - target: {fileID: 7336903875735698375, guid: b1e26fbb641dbc14db5a85bd1c511e00,
         type: 3}
       propertyPath: m_LocalPosition.x


### PR DESCRIPTION
Had to re-add laser tower audio to each scenes audio manager as wells as fix a spelling of the flametowershot as the flame tower was not playing its sfx like it should have.

Re-closes #203 